### PR TITLE
Don't need to run compile ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,12 +134,10 @@ For the remainder of the workshop we'll be looking at different ways of identify
 
 In [exercise 1](https://github.com/ConsenSys/devcon4-playground/tree/master/exercise1) we'll give a sneak peek of the `truffle analyze` command, an upcoming feature of [Truffle Suite](https://truffleframework.com). Let's see if Truffle can spot the security bug and think about ways to fix it.
 
-To run `truffle analyze`, first change into the project directory for exercise 1. Note that you need to compile the code before running the `truffle analyze` command.
-
+To run `truffle analyze`, first change into the project directory for exercise 1.
 ```
 $ cd devcon4-playground/exercise1
-$ truffle+analyze compile
-$ truffle+analyze analyze --timeout 60
+$ truffle+analyze analyze
 ```
 
 If you get an error message saying "You need to set environment variable MYTHRIL_API_KEY to run analyze", re-run the setup script which as described above.


### PR DESCRIPTION
nor do you need a timeout.

If the compile step could be removed to get rid of this message:

```
Compilation warnings encountered:

/Users/rocky/github/consensys/devcon4-playground/exercise1/contracts/Token.sol:13:3: Warning: Defining constructors as functions with the same name as the contract is deprecated. Use "constructor(...) { ... }" instead.
  function Token(uint _initialSupply) public {
  ^ (Relevant source part starts here and spans across multiple lines).
```

that'd be awesome.